### PR TITLE
aarch64: Product name update

### DIFF
--- a/adoc/aarch64.adoc
+++ b/adoc/aarch64.adoc
@@ -51,7 +51,7 @@ which have undergone compatibility testing.
 === {nvidiaorin} minimum firmware requirements
 
 // SLES 15 SP5 -> SLEM 5.5
-{productnameshort} {previous-version} added initial enablement for the
+{slea} Micro {previous-version} added initial enablement for the
 {nvidiaorinreg} SoC (T234), which is found on {jetsonreg} AGX{nbsp}{orin},
 {jetson} {orin}{nbsp}NX and {jetson} {orin}{nbsp}Nano System-on-Modules (SoM)
 as well as {nvidia} IGX{nbsp}Orin based systems.

--- a/adoc/aarch64.adoc
+++ b/adoc/aarch64.adoc
@@ -51,7 +51,7 @@ which have undergone compatibility testing.
 === {nvidiaorin} minimum firmware requirements
 
 // SLES 15 SP5 -> SLEM 5.5
-{slea} Micro {previous-version} added initial enablement for the
+{slesa} 15{nbsp}SP5 and {slea} Micro {previous-version} added initial enablement for the
 {nvidiaorinreg} SoC (T234), which is found on {jetsonreg} AGX{nbsp}{orin},
 {jetson} {orin}{nbsp}NX and {jetson} {orin}{nbsp}Nano System-on-Modules (SoM)
 as well as {nvidia} IGX{nbsp}Orin based systems.


### PR DESCRIPTION
Adjust the combination of `productnameshort` and `previous-version` for SUSE Linux Micro 6.0 to continue referencing SLE Micro 5.5.